### PR TITLE
Fixe decode types length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+* v0.2.1
+  * Bugfix: Decode function used a wrong length to decode data. All the types use now max(offset) + length as default length value
+  * Update the examples
+
 * v0.2.0
   * Promisify decode/encode functions to reduce the call stack size
   * Added more complex data tests (deep json and mixed data types)

--- a/README.md
+++ b/README.md
@@ -65,12 +65,7 @@ import Vector2 from 'gd-com/object/Vector2'
 import Rect2 from 'gd-com/object/Rect2'
 
 let v2 = new Vector2(3, 2)
-let v2Encoded = udp.encode(v2)
-let v2dencoded = udp.decode(v2Encoded)
-
 let r2 = new Rect2(1, 2, 3, 4)
-let r2Encoded = udp.encode(r2)
-let r2dencoded = udp.decode(r2Encoded)
 ```
 
 ### ES5
@@ -79,12 +74,7 @@ let r2dencoded = udp.decode(r2Encoded)
 var gdCom = require('gd-com')
 
 var v2 = new gdCom.objects.Vector2(3, 2)
-var v2Encoded = gdCom.UDP.encode(v2)
-var v2dencoded = gdCom.UDP.decode(v2Encoded)
-
 var r2 = new gdCom.objects.Rect2(1, 2, 3, 4)
-var r2Encoded = gdCom.UDP.encode(r2)
-var r2dencoded = gdCom.UDP.decode(r2Encoded)
 ```
 
 ## Contributing

--- a/examples/gd/godot2/tcp.gd
+++ b/examples/gd/godot2/tcp.gd
@@ -12,11 +12,18 @@ func _init():
 	connection.connect("127.0.0.1", 8080)
 	peerstream = PacketPeerStream.new()
 	peerstream.set_stream_peer(connection)
-	peerstream.put_var([true,false,1,2,12.3,-15.3,"test", ["test",true,false]])
+	peerstream.put_var({
+		'test': 'test',
+		'vector2': Vector2(2.2, 3.3),
+		'matrix': Matrix32(Vector2(2.2, 3.3), Vector2(2.2, 3.3), Vector2(2.2, 3.3))
+	})
 
 	while(true):
-	    if connection.is_connected() && connection.get_available_bytes() >0:
-            test = connection.get_var()
-            print(typeof(test))
-            print(test)
-            quit()
+		if connection.is_connected() && connection.get_available_bytes() >0:
+			print('GOT VALUE')
+			test = connection.get_var()
+			print(typeof(test))
+			print(test)
+			break
+
+	quit()

--- a/examples/js/tcp.js
+++ b/examples/js/tcp.js
@@ -1,13 +1,21 @@
 const net = require('net')
-const gdCom = require('../lib')
+const gdCom = require('../../lib')
 
 let server = net.createServer(function (socket) {
   socket.on('data', function (data) {
-    let vector = gdCom.objects.Vector2(2, 3)
+    let vector = new gdCom.objects.Vector2(2, 3)
 
-    return gdCom.TCP.encode(vector)
-      .then(Buffer.from)
-      .then(socket.write)
+    return gdCom.TCP.decode(data)
+      .then((value) => console.log(value))
+      .then(() => gdCom.TCP.encode(vector))
+      .then((data) => {
+        let buffer = Buffer.from(data)
+
+        return socket.write(buffer)
+      })
+      .catch((err) => {
+        console.log(err)
+      })
   })
 
   socket.on('error', () => console.log('Bye :('))

--- a/examples/js/udp.js
+++ b/examples/js/udp.js
@@ -1,5 +1,5 @@
 const dgram = require('dgram')
-const gdCom = require('../lib')
+const gdCom = require('../../lib')
 
 let server = dgram.createSocket('udp4')
 

--- a/lib/decode/aabb.js
+++ b/lib/decode/aabb.js
@@ -20,7 +20,7 @@ function decode (genericDecoder, offset, buf) {
         z: buf.readFloatLE(24)
       },
 
-      length: 4 * 6
+      length: 24 + 4
     }
   })
 }

--- a/lib/decode/boolean.js
+++ b/lib/decode/boolean.js
@@ -8,7 +8,7 @@
 function decode (genericDecoder, offset, buf) {
   return Promise.resolve({
     value: buf.readUInt32LE(4) === 1,
-    length: 8
+    length: 4 + 4
   })
 }
 

--- a/lib/decode/color.js
+++ b/lib/decode/color.js
@@ -14,7 +14,7 @@ function decode (genericDecoder, offset, buf) {
       a: buf.readFloatLE(16)
     },
 
-    length: 4 * 4
+    length: 16 + 4
   })
 }
 

--- a/lib/decode/dictionnary.js
+++ b/lib/decode/dictionnary.js
@@ -13,7 +13,6 @@ function decode (genericDecoder, offset, buf) {
   })
 
   for (let index = 0; index < nrEntries; index++) {
-    // start from 8
     promise = promise.then(({dictionary, bufferPosition}) => genericDecoder(offset, buf.slice(bufferPosition))
       .then((decodedKey) => {
         bufferPosition += decodedKey.length

--- a/lib/decode/float.js
+++ b/lib/decode/float.js
@@ -8,7 +8,7 @@
 function decode (genericDecoder, offset, buf) {
   return Promise.resolve({
     value: buf.readFloatLE(4),
-    length: 8
+    length: 4 + 4
   })
 }
 

--- a/lib/decode/index.js
+++ b/lib/decode/index.js
@@ -37,7 +37,7 @@ function decode (offset, pBuf, firstCall = false) {
   const type = buf.readUInt32LE(0)
 
   if (decoderList[type] == null) {
-    return new Error(`Decode buffer error: Invalid type ${type}`)
+    throw new Error(`Decode buffer error: Invalid type ${type}`)
   }
 
   return decoderList[type](decode, offset, buf)

--- a/lib/decode/integer.js
+++ b/lib/decode/integer.js
@@ -8,7 +8,7 @@
 function decode (genericDecoder, offset, buf) {
   return Promise.resolve({
     value: buf.readInt32LE(4),
-    length: 8
+    length: 4 + 4
   })
 }
 

--- a/lib/decode/matrix32.js
+++ b/lib/decode/matrix32.js
@@ -20,7 +20,7 @@ function decode (genericDecoder, offset, buf) {
       ]
     ],
 
-    length: 4 * 6
+    length: 24 + 4
   })
 }
 

--- a/lib/decode/matrix33.js
+++ b/lib/decode/matrix33.js
@@ -23,7 +23,7 @@ function decode (genericDecoder, offset, buf) {
       ]
     ],
 
-    length: 4 * 9
+    length: 36 + 4
   })
 }
 

--- a/lib/decode/plane.js
+++ b/lib/decode/plane.js
@@ -11,9 +11,9 @@ function decode (genericDecoder, offset, buf) {
       x: buf.readFloatLE(4),
       y: buf.readFloatLE(8),
       z: buf.readFloatLE(12),
-      dist: buf.readFloatLE(16)
+      distance: buf.readFloatLE(16)
     },
-    length: 4 * 4
+    length: 16 + 4
   })
 }
 

--- a/lib/decode/quaternion.js
+++ b/lib/decode/quaternion.js
@@ -14,12 +14,10 @@ function decode (genericDecoder, offset, buf) {
         z: buf.readFloatLE(12)
       },
       size: {
-        x: buf.readFloatLE(16),
-        y: buf.readFloatLE(20),
-        z: buf.readFloatLE(24)
+        w: buf.readFloatLE(16),
       }
     },
-    length: 4 * 6
+    length: 16 + 4
   })
 }
 

--- a/lib/decode/rect2.js
+++ b/lib/decode/rect2.js
@@ -16,7 +16,7 @@ function decode (genericDecoder, offset, buf) {
       buf.readFloatLE(16)
     ),
 
-    length: 4 * 4
+    length: 16 + 4
   })
 }
 

--- a/lib/decode/transform.js
+++ b/lib/decode/transform.js
@@ -27,7 +27,7 @@ function decode (genericDecoder, offset, buf) {
       ]
     ],
 
-    length: 4 * 12
+    length: 48 + 4
   })
 }
 

--- a/lib/decode/vector2.js
+++ b/lib/decode/vector2.js
@@ -10,7 +10,7 @@ var Vector2 = require('../object/Vector2')
 function decode (genericDecoder, offset, buf) {
   return Promise.resolve({
     value: new Vector2(buf.readFloatLE(4), buf.readFloatLE(8)),
-    length: 4 * 2
+    length: 8 + 4
   })
 }
 

--- a/lib/decode/vector3.js
+++ b/lib/decode/vector3.js
@@ -7,20 +7,12 @@
  */
 function decode (genericDecoder, offset, buf) {
   return Promise.resolve({
-    value: [
-      [
-        buf.readFloatLE(4),
-        buf.readFloatLE(8)
-      ], [
-        buf.readFloatLE(12),
-        buf.readFloatLE(16)
-      ], [
-        buf.readFloatLE(20),
-        buf.readFloatLE(24)
-      ]
-    ],
-
-    length: 4 * 6
+    value: {
+      x: buf.readFloatLE(4),
+      y: buf.readFloatLE(8),
+      z: buf.readFloatLE(12)
+    },
+    length: 12 + 4
   })
 }
 

--- a/lib/encode/index.js
+++ b/lib/encode/index.js
@@ -47,7 +47,7 @@ function prepare (value) {
   let encoder = encoderList.filter((encoder) => encoder.type(typeName, value))
 
   if (encoder.length !== 1) {
-    return new Error(`Invalid value: no matching encoder found ${value}:${typeName}`)
+    throw new Error(`Invalid value: no matching encoder found ${value}:${typeName}`)
   }
 
   return encoder[0].encode(prepare, value)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gd-com",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Serializer/deserializer helper for godot engine",
   "main": "lib/index.js",
   "scripts": {

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -15,6 +15,12 @@ let data = {
     12: -12,
     test: 'test',
     dataDeepFile
+  }, {
+    test: 'test',
+    position: [ new gdCom.objects.Rect2(2, 3, 4, 5) ]
+  }, {
+    test: 'test',
+    position: [ new gdCom.objects.Vector2(2, 3) ]
   }],
   Array: [
     [ true, false, 12, -12, 'test', 'test2' ],


### PR DESCRIPTION
Bugfix: Decode function used a wrong length to decode data. All the types use now max(offset) + length as default length value
Update the examples