### PR TITLE
Remove all async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ var wanted = 'test'
 
 const buff = new gdCom.GdBuffer()
 
-await buff.putVar(wanted)
+buff.putVar(wanted)
 
-const recieved = await buff.getVar()
+const recieved = buff.getVar()
 
 console.log(recieved === wanted) // is true
 
@@ -127,14 +127,14 @@ const { StreamTcp, GdBuffer, addLengthFront } = require('@gd-com/utils')
 
 let server = net.createServer((socket) => {
   const tcpSplit = new StreamTcp()
-  socket.pipe(tcpSplit).on('data', async (data) => {
+  socket.pipe(tcpSplit).on('data', (data) => {
     const packet = new GdBuffer(data)
 
-    const decoded = await packet.getVar()
+    const decoded = packet.getVar()
     console.log('receive :', decoded)
 
     const packetToSend = new GdBuffer()
-    await packetToSend.putVar(Math.random())
+    packetToSend.putVar(Math.random())
 
     // we need to put the packet length on top cause it's tcp
     let toSend = addLengthFront(packetToSend.getBuffer())

--- a/src/buffer/GdBuffer.js
+++ b/src/buffer/GdBuffer.js
@@ -2,17 +2,17 @@ const Get = require('../get')
 const Put = require('../put')
 
 class GdBuffer {
-  constructor(buffer = Buffer.alloc(0)) {
+  constructor (buffer = Buffer.alloc(0)) {
     this._buffer = buffer
   }
 
-  _internalGet(method) {
+  _internalGet (method) {
     let result = method(this._buffer)
     this._buffer = this._buffer.slice(result.length)
     return result.value
   }
 
-  _internalPut(method, data) {
+  _internalPut (method, data) {
     let result = method(data)
     if (this._buffer.length > 0) {
       return Buffer.concat([this._buffer, result])
@@ -20,103 +20,103 @@ class GdBuffer {
     return result
   }
 
-  putVar(data) {
+  putVar (data) {
     this._buffer = this._internalPut(Put.putVar, data)
   }
 
-  put8(data) {
+  put8 (data) {
     this._buffer = this._internalPut(Put.put8, data)
   }
 
-  put16(data) {
+  put16 (data) {
     this._buffer = this._internalPut(Put.put16, data)
   }
 
-  put32(data) {
+  put32 (data) {
     this._buffer = this._internalPut(Put.put32, data)
   }
 
-  put64(data) {
+  put64 (data) {
     this._buffer = this._internalPut(Put.put64, data)
   }
 
-  putU8(data) {
+  putU8 (data) {
     this._buffer = this._internalPut(Put.putU8, data)
   }
 
-  putU16(data) {
+  putU16 (data) {
     this._buffer = this._internalPut(Put.putU16, data)
   }
 
-  putU32(data) {
+  putU32 (data) {
     this._buffer = this._internalPut(Put.putU32, data)
   }
 
-  putU64(data) {
+  putU64 (data) {
     this._buffer = this._internalPut(Put.putU64, data)
   }
 
-  putFloat(data) {
+  putFloat (data) {
     this._buffer = this._internalPut(Put.putFloat, data)
   }
 
-  putDouble(data) {
+  putDouble (data) {
     this._buffer = this._internalPut(Put.putDouble, data)
   }
 
-  putString(data) {
+  putString (data) {
     this._buffer = this._internalPut(Put.putString, data)
   }
 
-  getVar() {
+  getVar () {
     return this._internalGet(Get.getVar)
   }
 
-  get8() {
+  get8 () {
     return this._internalGet(Get.get8)
   }
 
-  get16() {
+  get16 () {
     return this._internalGet(Get.get16)
   }
 
-  get32() {
+  get32 () {
     return this._internalGet(Get.get32)
   }
 
-  get64() {
+  get64 () {
     return this._internalGet(Get.get64)
   }
 
-  getU8() {
+  getU8 () {
     return this._internalGet(Get.getU8)
   }
 
-  getU16() {
+  getU16 () {
     return this._internalGet(Get.getU16)
   }
 
-  getU32() {
+  getU32 () {
     return this._internalGet(Get.getU32)
   }
 
-  getU64() {
+  getU64 () {
     return this._internalGet(Get.getU64)
   }
 
-  getFloat() {
+  getFloat () {
     return this._internalGet(Get.getFloat)
   }
 
-  getDouble() {
+  getDouble () {
     return this._internalGet(Get.getDouble)
   }
 
-  getString() {
+  getString () {
     return this._internalGet(Get.getString)
   }
 
-  getBuffer() {
+  getBuffer () {
     return this._buffer
   }
 }

--- a/src/buffer/GdBuffer.js
+++ b/src/buffer/GdBuffer.js
@@ -2,121 +2,121 @@ const Get = require('../get')
 const Put = require('../put')
 
 class GdBuffer {
-  constructor (buffer = Buffer.alloc(0)) {
+  constructor(buffer = Buffer.alloc(0)) {
     this._buffer = buffer
   }
 
-  async _internalGet (method) {
-    let result = await method(this._buffer)
+  _internalGet(method) {
+    let result = method(this._buffer)
     this._buffer = this._buffer.slice(result.length)
     return result.value
   }
 
-  async _internalPut (method, data) {
-    let result = await method(data)
+  _internalPut(method, data) {
+    let result = method(data)
     if (this._buffer.length > 0) {
       return Buffer.concat([this._buffer, result])
     }
     return result
   }
 
-  async putVar (data) {
-    this._buffer = await this._internalPut(Put.putVar, data)
+  putVar(data) {
+    this._buffer = this._internalPut(Put.putVar, data)
   }
 
-  async put8 (data) {
-    this._buffer = await this._internalPut(Put.put8, data)
+  put8(data) {
+    this._buffer = this._internalPut(Put.put8, data)
   }
 
-  async put16 (data) {
-    this._buffer = await this._internalPut(Put.put16, data)
+  put16(data) {
+    this._buffer = this._internalPut(Put.put16, data)
   }
 
-  async put32 (data) {
-    this._buffer = await this._internalPut(Put.put32, data)
+  put32(data) {
+    this._buffer = this._internalPut(Put.put32, data)
   }
 
-  async put64 (data) {
-    this._buffer = await this._internalPut(Put.put64, data)
+  put64(data) {
+    this._buffer = this._internalPut(Put.put64, data)
   }
 
-  async putU8 (data) {
-    this._buffer = await this._internalPut(Put.putU8, data)
+  putU8(data) {
+    this._buffer = this._internalPut(Put.putU8, data)
   }
 
-  async putU16 (data) {
-    this._buffer = await this._internalPut(Put.putU16, data)
+  putU16(data) {
+    this._buffer = this._internalPut(Put.putU16, data)
   }
 
-  async putU32 (data) {
-    this._buffer = await this._internalPut(Put.putU32, data)
+  putU32(data) {
+    this._buffer = this._internalPut(Put.putU32, data)
   }
 
-  async putU64 (data) {
-    this._buffer = await this._internalPut(Put.putU64, data)
+  putU64(data) {
+    this._buffer = this._internalPut(Put.putU64, data)
   }
 
-  async putFloat (data) {
-    this._buffer = await this._internalPut(Put.putFloat, data)
+  putFloat(data) {
+    this._buffer = this._internalPut(Put.putFloat, data)
   }
 
-  async putDouble (data) {
-    this._buffer = await this._internalPut(Put.putDouble, data)
+  putDouble(data) {
+    this._buffer = this._internalPut(Put.putDouble, data)
   }
 
-  async putString (data) {
-    this._buffer = await this._internalPut(Put.putString, data)
+  putString(data) {
+    this._buffer = this._internalPut(Put.putString, data)
   }
 
-  async getVar () {
+  getVar() {
     return this._internalGet(Get.getVar)
   }
 
-  async get8 () {
+  get8() {
     return this._internalGet(Get.get8)
   }
 
-  async get16 () {
+  get16() {
     return this._internalGet(Get.get16)
   }
 
-  async get32 () {
+  get32() {
     return this._internalGet(Get.get32)
   }
 
-  async get64 () {
+  get64() {
     return this._internalGet(Get.get64)
   }
 
-  async getU8 () {
+  getU8() {
     return this._internalGet(Get.getU8)
   }
 
-  async getU16 () {
+  getU16() {
     return this._internalGet(Get.getU16)
   }
 
-  async getU32 () {
+  getU32() {
     return this._internalGet(Get.getU32)
   }
 
-  async getU64 () {
+  getU64() {
     return this._internalGet(Get.getU64)
   }
 
-  async getFloat () {
+  getFloat() {
     return this._internalGet(Get.getFloat)
   }
 
-  async getDouble () {
+  getDouble() {
     return this._internalGet(Get.getDouble)
   }
 
-  async getString () {
+  getString() {
     return this._internalGet(Get.getString)
   }
 
-  getBuffer () {
+  getBuffer() {
     return this._buffer
   }
 }

--- a/src/get/get_16.js
+++ b/src/get/get_16.js
@@ -1,4 +1,4 @@
-function get16(buffer, offset = 0) {
+function get16 (buffer, offset = 0) {
   return {
     value: buffer.readInt16LE(offset),
     length: 2

--- a/src/get/get_16.js
+++ b/src/get/get_16.js
@@ -1,4 +1,4 @@
-async function get16 (buffer, offset = 0) {
+function get16(buffer, offset = 0) {
   return {
     value: buffer.readInt16LE(offset),
     length: 2

--- a/src/get/get_32.js
+++ b/src/get/get_32.js
@@ -1,4 +1,4 @@
-async function get32 (buffer, offset = 0) {
+function get32(buffer, offset = 0) {
   return {
     value: buffer.readInt32LE(offset),
     length: 4

--- a/src/get/get_32.js
+++ b/src/get/get_32.js
@@ -1,4 +1,4 @@
-function get32(buffer, offset = 0) {
+function get32 (buffer, offset = 0) {
   return {
     value: buffer.readInt32LE(offset),
     length: 4

--- a/src/get/get_64.js
+++ b/src/get/get_64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-function get64(buffer, offset = 0) {
+function get64 (buffer, offset = 0) {
   return {
     value: Long.fromBytesLE(buffer.slice(offset)).toString(),
     length: 8

--- a/src/get/get_64.js
+++ b/src/get/get_64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-async function get64 (buffer, offset = 0) {
+function get64(buffer, offset = 0) {
   return {
     value: Long.fromBytesLE(buffer.slice(offset)).toString(),
     length: 8

--- a/src/get/get_8.js
+++ b/src/get/get_8.js
@@ -1,4 +1,4 @@
-function get8(buffer, offset = 0) {
+function get8 (buffer, offset = 0) {
   return {
     value: buffer.readInt8(offset),
     length: 1

--- a/src/get/get_8.js
+++ b/src/get/get_8.js
@@ -1,4 +1,4 @@
-async function get8 (buffer, offset = 0) {
+function get8(buffer, offset = 0) {
   return {
     value: buffer.readInt8(offset),
     length: 1

--- a/src/get/get_double.js
+++ b/src/get/get_double.js
@@ -1,4 +1,4 @@
-async function getDouble (buffer, offset = 0) {
+function getDouble(buffer, offset = 0) {
   return {
     value: buffer.readDoubleLE(offset),
     length: 8

--- a/src/get/get_double.js
+++ b/src/get/get_double.js
@@ -1,4 +1,4 @@
-function getDouble(buffer, offset = 0) {
+function getDouble (buffer, offset = 0) {
   return {
     value: buffer.readDoubleLE(offset),
     length: 8

--- a/src/get/get_float.js
+++ b/src/get/get_float.js
@@ -1,4 +1,4 @@
-async function getFloat (buffer, offset = 0) {
+function getFloat(buffer, offset = 0) {
   return {
     value: buffer.readFloatLE(offset),
     length: 4

--- a/src/get/get_float.js
+++ b/src/get/get_float.js
@@ -1,4 +1,4 @@
-function getFloat(buffer, offset = 0) {
+function getFloat (buffer, offset = 0) {
   return {
     value: buffer.readFloatLE(offset),
     length: 4

--- a/src/get/get_string.js
+++ b/src/get/get_string.js
@@ -1,4 +1,4 @@
-function getString(buffer, offset = 0) {
+function getString (buffer, offset = 0) {
   const len = buffer.readUInt32LE(offset)
   const pad = len % 4 === 0 ? 0 : 4 - (len % 4)
 

--- a/src/get/get_string.js
+++ b/src/get/get_string.js
@@ -1,4 +1,4 @@
-async function getString (buffer, offset = 0) {
+function getString(buffer, offset = 0) {
   const len = buffer.readUInt32LE(offset)
   const pad = len % 4 === 0 ? 0 : 4 - (len % 4)
 

--- a/src/get/get_u16.js
+++ b/src/get/get_u16.js
@@ -1,4 +1,4 @@
-function getU16(buffer, offset = 0) {
+function getU16 (buffer, offset = 0) {
   return {
     value: buffer.readUInt16LE(offset),
     length: 2

--- a/src/get/get_u16.js
+++ b/src/get/get_u16.js
@@ -1,4 +1,4 @@
-async function getU16 (buffer, offset = 0) {
+function getU16(buffer, offset = 0) {
   return {
     value: buffer.readUInt16LE(offset),
     length: 2

--- a/src/get/get_u32.js
+++ b/src/get/get_u32.js
@@ -1,4 +1,4 @@
-function getU32(buffer, offset = 0) {
+function getU32 (buffer, offset = 0) {
   return {
     value: buffer.readUInt32LE(offset),
     length: 4

--- a/src/get/get_u32.js
+++ b/src/get/get_u32.js
@@ -1,4 +1,4 @@
-async function getU32 (buffer, offset = 0) {
+function getU32(buffer, offset = 0) {
   return {
     value: buffer.readUInt32LE(offset),
     length: 4

--- a/src/get/get_u64.js
+++ b/src/get/get_u64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-function getU64(buffer, offset = 0) {
+function getU64 (buffer, offset = 0) {
   return {
     value: Long.fromBytesLE(buffer.slice(offset), true).toString(),
     length: 8

--- a/src/get/get_u64.js
+++ b/src/get/get_u64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-async function getU64 (buffer, offset = 0) {
+function getU64(buffer, offset = 0) {
   return {
     value: Long.fromBytesLE(buffer.slice(offset), true).toString(),
     length: 8

--- a/src/get/get_u8.js
+++ b/src/get/get_u8.js
@@ -1,4 +1,4 @@
-async function getU8 (buffer, offset = 0) {
+function getU8(buffer, offset = 0) {
   return {
     value: buffer.readUInt8(offset),
     length: 1

--- a/src/get/get_u8.js
+++ b/src/get/get_u8.js
@@ -1,4 +1,4 @@
-function getU8(buffer, offset = 0) {
+function getU8 (buffer, offset = 0) {
   return {
     value: buffer.readUInt8(offset),
     length: 1

--- a/src/get/get_var/aabb.js
+++ b/src/get/get_var/aabb.js
@@ -6,7 +6,7 @@ const { AABB } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/aabb.js
+++ b/src/get/get_var/aabb.js
@@ -6,7 +6,7 @@ const { AABB } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/array.js
+++ b/src/get/get_var/array.js
@@ -6,7 +6,7 @@ const { ARRAY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   const nbEntries = buf.readUInt32LE(0) & 0x7FFFFFFF
   // const shared = !!buf.readUInt32LE(0) & 0x80000000
 

--- a/src/get/get_var/array.js
+++ b/src/get/get_var/array.js
@@ -6,7 +6,7 @@ const { ARRAY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   const nbEntries = buf.readUInt32LE(0) & 0x7FFFFFFF
   // const shared = !!buf.readUInt32LE(0) & 0x80000000
 
@@ -18,7 +18,7 @@ async function decode (genericDecoder, buf) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await genericDecoder(data.buffer)
+    const decodedValue = genericDecoder(data.buffer)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length + 4)
     data.pos += decodedValue.length + 4

--- a/src/get/get_var/basis.js
+++ b/src/get/get_var/basis.js
@@ -6,7 +6,7 @@ const { BASIS } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/basis.js
+++ b/src/get/get_var/basis.js
@@ -6,7 +6,7 @@ const { BASIS } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/bool.js
+++ b/src/get/get_var/bool.js
@@ -6,7 +6,7 @@ const { BOOL } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: buf.readUInt32LE(0) === 1,
     length: 4

--- a/src/get/get_var/bool.js
+++ b/src/get/get_var/bool.js
@@ -6,7 +6,7 @@ const { BOOL } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: buf.readUInt32LE(0) === 1,
     length: 4

--- a/src/get/get_var/color.js
+++ b/src/get/get_var/color.js
@@ -6,7 +6,7 @@ const { COLOR } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: {
       r: buf.readFloatLE(0),

--- a/src/get/get_var/color.js
+++ b/src/get/get_var/color.js
@@ -6,7 +6,7 @@ const { COLOR } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       r: buf.readFloatLE(0),

--- a/src/get/get_var/colorArray.js
+++ b/src/get/get_var/colorArray.js
@@ -8,7 +8,7 @@ const color = require('./color')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await color.decode(genericDecoder, data.buffer)
+    const decodedValue = color.decode(genericDecoder, data.buffer)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/colorArray.js
+++ b/src/get/get_var/colorArray.js
@@ -8,7 +8,7 @@ const color = require('./color')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/get/get_var/dictionnary.js
+++ b/src/get/get_var/dictionnary.js
@@ -6,7 +6,7 @@ const { DICTIONARY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   const nbEntries = buf.readUInt32LE(0) & 0x7FFFFFFF
   // const shared = !!buf.readUInt32LE(0) & 0x80000000
 
@@ -17,11 +17,11 @@ async function decode (genericDecoder, buf) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedKey = await genericDecoder(data.buffer)
+    const decodedKey = genericDecoder(data.buffer)
     data.pos += decodedKey.length + 4 // 4 type length
     let nextBuffer = data.buffer.slice(decodedKey.length + 4)
 
-    const decodedValue = await genericDecoder(nextBuffer)
+    const decodedValue = genericDecoder(nextBuffer)
     data.pos += decodedValue.length + 4 // 4 type length
     data.dictionary[decodedKey.value] = decodedValue.value
     data.buffer = nextBuffer.slice(decodedValue.length + 4)

--- a/src/get/get_var/dictionnary.js
+++ b/src/get/get_var/dictionnary.js
@@ -6,7 +6,7 @@ const { DICTIONARY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   const nbEntries = buf.readUInt32LE(0) & 0x7FFFFFFF
   // const shared = !!buf.readUInt32LE(0) & 0x80000000
 

--- a/src/get/get_var/float.js
+++ b/src/get/get_var/float.js
@@ -7,7 +7,7 @@ const { FLOAT } = require('../../constants')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   let result = null
   // always encode real as double cf : marshalls.cpp L842
   // but sometimes can be float if double is not necessary

--- a/src/get/get_var/float.js
+++ b/src/get/get_var/float.js
@@ -7,7 +7,7 @@ const { FLOAT } = require('../../constants')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   let result = null
   // always encode real as double cf : marshalls.cpp L842
   // but sometimes can be float if double is not necessary

--- a/src/get/get_var/index.js
+++ b/src/get/get_var/index.js
@@ -24,7 +24,7 @@ const decoderList = files.reduce((decoders, filename) => {
  * @param offset
  * @returns {*}
  */
-function decode(buffer, offset = 0) {
+function decode (buffer, offset = 0) {
   const type = buffer.readInt16LE(offset)
   const flag = buffer.readInt16LE(offset + 2)
   const data = buffer.slice(offset + 4)
@@ -37,6 +37,6 @@ function decode(buffer, offset = 0) {
 }
 
 module.exports = (buf) => {
-  var data = decode(buf);
+  var data = decode(buf)
   return { value: data.value, length: data.length + 4 } // +4 cause we don't export type length
-};
+}

--- a/src/get/get_var/index.js
+++ b/src/get/get_var/index.js
@@ -8,8 +8,8 @@ const decoderList = files.reduce((decoders, filename) => {
   const extname = path.extname(filePath)
 
   if (fs.statSync(filePath).isFile() &&
-      /^\.js$/i.test(extname) &&
-      __filename !== filePath) {
+    /^\.js$/i.test(extname) &&
+    __filename !== filePath) {
     let decoder = require(filePath)
 
     decoders[decoder.type] = decoder.decode
@@ -24,7 +24,7 @@ const decoderList = files.reduce((decoders, filename) => {
  * @param offset
  * @returns {*}
  */
-async function decode (buffer, offset = 0) {
+function decode(buffer, offset = 0) {
   const type = buffer.readInt16LE(offset)
   const flag = buffer.readInt16LE(offset + 2)
   const data = buffer.slice(offset + 4)
@@ -36,4 +36,7 @@ async function decode (buffer, offset = 0) {
   return decoderList[type](decode, data, flag)
 }
 
-module.exports = (buf) => decode(buf).then((data) => ({ value: data.value, length: data.length + 4 })) // +4 cause we don't export type length
+module.exports = (buf) => {
+  var data = decode(buf);
+  return { value: data.value, length: data.length + 4 } // +4 cause we don't export type length
+};

--- a/src/get/get_var/intArray.js
+++ b/src/get/get_var/intArray.js
@@ -8,7 +8,7 @@ const integer = require('./integer')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await integer.decode(genericDecoder, data.buffer, flag)
+    const decodedValue = integer.decode(genericDecoder, data.buffer, flag)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/intArray.js
+++ b/src/get/get_var/intArray.js
@@ -8,7 +8,7 @@ const integer = require('./integer')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/get/get_var/integer.js
+++ b/src/get/get_var/integer.js
@@ -8,7 +8,7 @@ const Long = require('long')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag = 0) {
+function decode (genericDecoder, buf, flag = 0) {
   let result = null
   if (flag === 1) {
     result = {

--- a/src/get/get_var/integer.js
+++ b/src/get/get_var/integer.js
@@ -8,7 +8,7 @@ const Long = require('long')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag = 0) {
+function decode(genericDecoder, buf, flag = 0) {
   let result = null
   if (flag === 1) {
     result = {

--- a/src/get/get_var/null.js
+++ b/src/get/get_var/null.js
@@ -6,7 +6,7 @@ const { NULL } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: null,
     length: 0

--- a/src/get/get_var/null.js
+++ b/src/get/get_var/null.js
@@ -6,7 +6,7 @@ const { NULL } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: null,
     length: 0

--- a/src/get/get_var/plane.js
+++ b/src/get/get_var/plane.js
@@ -6,7 +6,7 @@ const { PLANE } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/plane.js
+++ b/src/get/get_var/plane.js
@@ -6,7 +6,7 @@ const { PLANE } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/quat.js
+++ b/src/get/get_var/quat.js
@@ -6,7 +6,7 @@ const { QUAT } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       coordinate: {

--- a/src/get/get_var/quat.js
+++ b/src/get/get_var/quat.js
@@ -6,7 +6,7 @@ const { QUAT } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: {
       coordinate: {

--- a/src/get/get_var/rawArray.js
+++ b/src/get/get_var/rawArray.js
@@ -5,7 +5,7 @@ const { RAW_ARRAY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   const bufLength = buf.readUInt32LE(0)
 
   return {

--- a/src/get/get_var/rawArray.js
+++ b/src/get/get_var/rawArray.js
@@ -5,7 +5,7 @@ const { RAW_ARRAY } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   const bufLength = buf.readUInt32LE(0)
 
   return {

--- a/src/get/get_var/realArray.js
+++ b/src/get/get_var/realArray.js
@@ -8,7 +8,7 @@ const float = require('./float')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/get/get_var/realArray.js
+++ b/src/get/get_var/realArray.js
@@ -8,7 +8,7 @@ const float = require('./float')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await float.decode(genericDecoder, data.buffer, flag)
+    const decodedValue = float.decode(genericDecoder, data.buffer, flag)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/rect2.js
+++ b/src/get/get_var/rect2.js
@@ -6,7 +6,7 @@ const { RECT2 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+ function decode (genericDecoder, buf) {
   return {
     value: {
       x1: buf.readFloatLE(0),

--- a/src/get/get_var/rect2.js
+++ b/src/get/get_var/rect2.js
@@ -6,7 +6,7 @@ const { RECT2 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
- function decode (genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       x1: buf.readFloatLE(0),

--- a/src/get/get_var/string.js
+++ b/src/get/get_var/string.js
@@ -5,7 +5,7 @@ const { STRING } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   const len = buf.readUInt32LE(0)
   const pad = len % 4 === 0 ? 0 : 4 - (len % 4)
 

--- a/src/get/get_var/string.js
+++ b/src/get/get_var/string.js
@@ -5,7 +5,7 @@ const { STRING } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   const len = buf.readUInt32LE(0)
   const pad = len % 4 === 0 ? 0 : 4 - (len % 4)
 

--- a/src/get/get_var/stringArray.js
+++ b/src/get/get_var/stringArray.js
@@ -8,7 +8,7 @@ const string = require('./string')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await string.decode(genericDecoder, data.buffer)
+    const decodedValue = string.decode(genericDecoder, data.buffer)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/stringArray.js
+++ b/src/get/get_var/stringArray.js
@@ -8,7 +8,7 @@ const string = require('./string')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/get/get_var/transform.js
+++ b/src/get/get_var/transform.js
@@ -6,7 +6,7 @@ const { TRANSFORM } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/transform.js
+++ b/src/get/get_var/transform.js
@@ -6,7 +6,7 @@ const { TRANSFORM } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/transform2d.js
+++ b/src/get/get_var/transform2d.js
@@ -6,7 +6,7 @@ const { TRANSFORM2D } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/transform2d.js
+++ b/src/get/get_var/transform2d.js
@@ -6,7 +6,7 @@ const { TRANSFORM2D } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: [
       [

--- a/src/get/get_var/vector2.js
+++ b/src/get/get_var/vector2.js
@@ -6,7 +6,7 @@ const { VECTOR2 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/vector2.js
+++ b/src/get/get_var/vector2.js
@@ -6,7 +6,7 @@ const { VECTOR2 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/vector2Array.js
+++ b/src/get/get_var/vector2Array.js
@@ -8,7 +8,7 @@ const vector2 = require('./vector2')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await vector2.decode(genericDecoder, data.buffer)
+    const decodedValue = vector2.decode(genericDecoder, data.buffer)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/vector2Array.js
+++ b/src/get/get_var/vector2Array.js
@@ -8,7 +8,7 @@ const vector2 = require('./vector2')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/get/get_var/vector3.js
+++ b/src/get/get_var/vector3.js
@@ -6,7 +6,7 @@ const { VECTOR3 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-function decode(genericDecoder, buf) {
+function decode (genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/vector3.js
+++ b/src/get/get_var/vector3.js
@@ -6,7 +6,7 @@ const { VECTOR3 } = require('../../constants')
  * @param buf
  * @returns {Object}
  */
-async function decode (genericDecoder, buf) {
+function decode(genericDecoder, buf) {
   return {
     value: {
       x: buf.readFloatLE(0),

--- a/src/get/get_var/vector3Array.js
+++ b/src/get/get_var/vector3Array.js
@@ -8,7 +8,7 @@ const vector3 = require('./vector3')
  * @param flag
  * @returns {Object}
  */
-async function decode (genericDecoder, buf, flag) {
+function decode(genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries
@@ -19,7 +19,7 @@ async function decode (genericDecoder, buf, flag) {
   }
 
   for (let index = 0; index < nbEntries; index++) {
-    const decodedValue = await vector3.decode(genericDecoder, data.buffer)
+    const decodedValue = vector3.decode(genericDecoder, data.buffer)
     data.array.push(decodedValue.value)
     data.buffer = data.buffer.slice(decodedValue.length)
     data.pos += decodedValue.length

--- a/src/get/get_var/vector3Array.js
+++ b/src/get/get_var/vector3Array.js
@@ -8,7 +8,7 @@ const vector3 = require('./vector3')
  * @param flag
  * @returns {Object}
  */
-function decode(genericDecoder, buf, flag) {
+function decode (genericDecoder, buf, flag) {
   const nbEntries = buf.readUInt32LE(0)
 
   // start at 4 cause of nbEntries

--- a/src/put/put_16.js
+++ b/src/put/put_16.js
@@ -1,4 +1,4 @@
-async function put16 (value) {
+function put16(value) {
   let newBuffer = Buffer.allocUnsafe(2)
   newBuffer.writeInt16LE(value, 0)
   return newBuffer

--- a/src/put/put_16.js
+++ b/src/put/put_16.js
@@ -1,4 +1,4 @@
-function put16(value) {
+function put16 (value) {
   let newBuffer = Buffer.allocUnsafe(2)
   newBuffer.writeInt16LE(value, 0)
   return newBuffer

--- a/src/put/put_32.js
+++ b/src/put/put_32.js
@@ -1,4 +1,4 @@
-function put32(value) {
+function put32 (value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeInt32LE(value, 0)
   return newBuffer

--- a/src/put/put_32.js
+++ b/src/put/put_32.js
@@ -1,4 +1,4 @@
-async function put32 (value) {
+function put32(value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeInt32LE(value, 0)
   return newBuffer

--- a/src/put/put_64.js
+++ b/src/put/put_64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-async function put64 (value) {
+function put64(value) {
   return Buffer.from(Long.fromString(value.toString()).toBytesLE())
 }
 

--- a/src/put/put_64.js
+++ b/src/put/put_64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-function put64(value) {
+function put64 (value) {
   return Buffer.from(Long.fromString(value.toString()).toBytesLE())
 }
 

--- a/src/put/put_8.js
+++ b/src/put/put_8.js
@@ -1,4 +1,4 @@
-async function put8 (value) {
+function put8(value) {
   let newBuffer = Buffer.allocUnsafe(1)
   newBuffer.writeInt8(value, 0)
   return newBuffer

--- a/src/put/put_8.js
+++ b/src/put/put_8.js
@@ -1,4 +1,4 @@
-function put8(value) {
+function put8 (value) {
   let newBuffer = Buffer.allocUnsafe(1)
   newBuffer.writeInt8(value, 0)
   return newBuffer

--- a/src/put/put_double.js
+++ b/src/put/put_double.js
@@ -1,4 +1,4 @@
-function putDouble(value) {
+function putDouble (value) {
   let newBuffer = Buffer.allocUnsafe(8)
   newBuffer.writeDoubleLE(value, 0)
   return newBuffer

--- a/src/put/put_double.js
+++ b/src/put/put_double.js
@@ -1,4 +1,4 @@
-async function putDouble (value) {
+function putDouble(value) {
   let newBuffer = Buffer.allocUnsafe(8)
   newBuffer.writeDoubleLE(value, 0)
   return newBuffer

--- a/src/put/put_float.js
+++ b/src/put/put_float.js
@@ -1,4 +1,4 @@
-async function putFloat (value) {
+function putFloat(value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeFloatLE(value, 0)
   return newBuffer

--- a/src/put/put_float.js
+++ b/src/put/put_float.js
@@ -1,4 +1,4 @@
-function putFloat(value) {
+function putFloat (value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeFloatLE(value, 0)
   return newBuffer

--- a/src/put/put_string.js
+++ b/src/put/put_string.js
@@ -1,4 +1,4 @@
-function putString(value) {
+function putString (value) {
   let len = Buffer.byteLength(value)
   let pad = len % 4 === 0 ? 0 : 4 - len % 4
   let newBuffer = Buffer.allocUnsafe(4 + len + pad)

--- a/src/put/put_string.js
+++ b/src/put/put_string.js
@@ -1,4 +1,4 @@
-async function putString (value) {
+function putString(value) {
   let len = Buffer.byteLength(value)
   let pad = len % 4 === 0 ? 0 : 4 - len % 4
   let newBuffer = Buffer.allocUnsafe(4 + len + pad)

--- a/src/put/put_u16.js
+++ b/src/put/put_u16.js
@@ -1,4 +1,4 @@
-async function putU16 (value) {
+function putU16(value) {
   let newBuffer = Buffer.allocUnsafe(2)
   newBuffer.writeUInt16LE(value, 0)
   return newBuffer

--- a/src/put/put_u16.js
+++ b/src/put/put_u16.js
@@ -1,4 +1,4 @@
-function putU16(value) {
+function putU16 (value) {
   let newBuffer = Buffer.allocUnsafe(2)
   newBuffer.writeUInt16LE(value, 0)
   return newBuffer

--- a/src/put/put_u32.js
+++ b/src/put/put_u32.js
@@ -1,4 +1,4 @@
-async function putU32 (value) {
+function putU32(value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeUInt32LE(value, 0)
   return newBuffer

--- a/src/put/put_u32.js
+++ b/src/put/put_u32.js
@@ -1,4 +1,4 @@
-function putU32(value) {
+function putU32 (value) {
   let newBuffer = Buffer.allocUnsafe(4)
   newBuffer.writeUInt32LE(value, 0)
   return newBuffer

--- a/src/put/put_u64.js
+++ b/src/put/put_u64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-function putU64(value) {
+function putU64 (value) {
   return Long.fromNumber(value, true).toBytesLE()
 }
 

--- a/src/put/put_u64.js
+++ b/src/put/put_u64.js
@@ -1,6 +1,6 @@
 const Long = require('long')
 
-async function putU64 (value) {
+function putU64(value) {
   return Long.fromNumber(value, true).toBytesLE()
 }
 

--- a/src/put/put_u8.js
+++ b/src/put/put_u8.js
@@ -1,4 +1,4 @@
-function putU8(value) {
+function putU8 (value) {
   let newBuffer = Buffer.allocUnsafe(1)
   newBuffer.writeUInt8(value, 0)
   return newBuffer

--- a/src/put/put_u8.js
+++ b/src/put/put_u8.js
@@ -1,4 +1,4 @@
-async function putU8 (value) {
+function putU8(value) {
   let newBuffer = Buffer.allocUnsafe(1)
   newBuffer.writeUInt8(value, 0)
   return newBuffer

--- a/src/put/put_var/array.js
+++ b/src/put/put_var/array.js
@@ -4,7 +4,7 @@ const { ARRAY } = require('../../constants')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   let len = 8
 
   for (let i in value) {
@@ -33,11 +33,11 @@ function encode(value) {
 module.exports = {
   encode: (prepare, array) => {
     var results = array.reduce((rawData, item) => {
-      var data = prepare(item);
-      rawData.push(data);
-      return rawData;
+      var data = prepare(item)
+      rawData.push(data)
+      return rawData
     }, [])
-    return encode(results);
+    return encode(results)
   },
   type: (typeName, value) => typeName === 'array'
 }

--- a/src/put/put_var/array.js
+++ b/src/put/put_var/array.js
@@ -4,7 +4,7 @@ const { ARRAY } = require('../../constants')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
+function encode(value) {
   let len = 8
 
   for (let i in value) {
@@ -32,14 +32,12 @@ async function encode (value) {
 
 module.exports = {
   encode: (prepare, array) => {
-    return array.reduce((promise, item) => {
-      return promise.then((rawData) => {
-        return prepare(item).then((data) => {
-          rawData.push(data)
-          return rawData
-        })
-      })
-    }, Promise.resolve([])).then(encode)
+    var results = array.reduce((rawData, item) => {
+      var data = prepare(item);
+      rawData.push(data);
+      return rawData;
+    }, [])
+    return encode(results);
   },
   type: (typeName, value) => typeName === 'array'
 }

--- a/src/put/put_var/bool.js
+++ b/src/put/put_var/bool.js
@@ -6,9 +6,9 @@ const putU32 = require('../put_u32')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
-  let type = await putU32(BOOL)
-  let data = await putU32(value ? 1 : 0)
+function encode(value) {
+  let type = putU32(BOOL)
+  let data = putU32(value ? 1 : 0)
   return Buffer.concat([type, data])
 }
 

--- a/src/put/put_var/bool.js
+++ b/src/put/put_var/bool.js
@@ -6,7 +6,7 @@ const putU32 = require('../put_u32')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   let type = putU32(BOOL)
   let data = putU32(value ? 1 : 0)
   return Buffer.concat([type, data])

--- a/src/put/put_var/dictionnary.js
+++ b/src/put/put_var/dictionnary.js
@@ -5,7 +5,7 @@ const { DICTIONARY } = require('../../constants')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
+function encode(value) {
   let len = 8
 
   for (let i in value) {
@@ -32,17 +32,13 @@ async function encode (value) {
 
 module.exports = {
   encode: (prepare, dictionary) => {
-    return Object.keys(dictionary).reduce((promise, key) => {
-      return promise.then(
-        (rawData) => prepare(key)
-          .then((rawKey) => prepare(dictionary[key])
-            .then((rawValue) => {
-              rawData.push(rawKey, rawValue)
-              return rawData
-            })
-          )
-      )
-    }, Promise.resolve([])).then(encode)
+    var results = Object.keys(dictionary).reduce((rawData, key) => {
+      var rawKey = prepare(key);
+      var rawValue = prepare(dictionary[key]);
+      rawData.push(rawKey, rawValue);
+      return rawData;
+    }, [])
+    return encode(results);
   },
   type: (typeName, value) => typeName === 'object'
 }

--- a/src/put/put_var/dictionnary.js
+++ b/src/put/put_var/dictionnary.js
@@ -5,7 +5,7 @@ const { DICTIONARY } = require('../../constants')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   let len = 8
 
   for (let i in value) {
@@ -33,12 +33,12 @@ function encode(value) {
 module.exports = {
   encode: (prepare, dictionary) => {
     var results = Object.keys(dictionary).reduce((rawData, key) => {
-      var rawKey = prepare(key);
-      var rawValue = prepare(dictionary[key]);
-      rawData.push(rawKey, rawValue);
-      return rawData;
+      var rawKey = prepare(key)
+      var rawValue = prepare(dictionary[key])
+      rawData.push(rawKey, rawValue)
+      return rawData
     }, [])
-    return encode(results);
+    return encode(results)
   },
   type: (typeName, value) => typeName === 'object'
 }

--- a/src/put/put_var/float.js
+++ b/src/put/put_var/float.js
@@ -7,7 +7,7 @@ const putFloat = require('../put_float')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
+function encode(value) {
   // always encode real as double cf : marshalls.cpp L842
   // if (x64) { // TODO x64
   // /* eslint-enable */
@@ -20,9 +20,9 @@ async function encode (value) {
   //   })
   // }
 
-  let type = await putU16(FLOAT)
-  let flag = await putU16(0) // flag  0 for float
-  let data = await putFloat(value)
+  let type = putU16(FLOAT)
+  let flag = putU16(0) // flag  0 for float
+  let data = putFloat(value)
 
   return Buffer.concat([type, flag, data])
 }

--- a/src/put/put_var/float.js
+++ b/src/put/put_var/float.js
@@ -7,7 +7,7 @@ const putFloat = require('../put_float')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   // always encode real as double cf : marshalls.cpp L842
   // if (x64) { // TODO x64
   // /* eslint-enable */

--- a/src/put/put_var/index.js
+++ b/src/put/put_var/index.js
@@ -8,25 +8,25 @@ const encoderList = files.reduce((encoders, filename) => {
   const extname = path.extname(filePath)
 
   if (fs.statSync(filePath).isFile() &&
-      /^\.js$/i.test(extname) &&
-      __filename !== filePath) {
+    /^\.js$/i.test(extname) &&
+    __filename !== filePath) {
     encoders.push(require(filePath))
   }
 
   return encoders
 }, [])
 
-function isObject (value) {
+function isObject(value) {
   const type = typeof value
 
   return value != null && (type === 'object' || type === 'function')
 }
 
-function isArray (value) {
+function isArray(value) {
   return Array.isArray(value)
 }
 
-function getType (value) {
+function getType(value) {
   if (value == null) {
     return 'null'
   }
@@ -46,7 +46,7 @@ function getType (value) {
  * @param value
  * @returns {*}
  */
-function prepare (value) {
+function prepare(value) {
   let typeName = getType(value)
   let encoder = encoderList.filter((encoder) => encoder.type(typeName, value))
 
@@ -63,5 +63,5 @@ function prepare (value) {
  * @returns {*}
  */
 module.exports = (value) => {
-  return prepare(value).then((d) => d)
+  return prepare(value)
 }

--- a/src/put/put_var/index.js
+++ b/src/put/put_var/index.js
@@ -16,17 +16,17 @@ const encoderList = files.reduce((encoders, filename) => {
   return encoders
 }, [])
 
-function isObject(value) {
+function isObject (value) {
   const type = typeof value
 
   return value != null && (type === 'object' || type === 'function')
 }
 
-function isArray(value) {
+function isArray (value) {
   return Array.isArray(value)
 }
 
-function getType(value) {
+function getType (value) {
   if (value == null) {
     return 'null'
   }
@@ -46,7 +46,7 @@ function getType(value) {
  * @param value
  * @returns {*}
  */
-function prepare(value) {
+function prepare (value) {
   let typeName = getType(value)
   let encoder = encoderList.filter((encoder) => encoder.type(typeName, value))
 

--- a/src/put/put_var/integer.js
+++ b/src/put/put_var/integer.js
@@ -7,10 +7,10 @@ const put32 = require('../put_32')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
-  let type = await putU16(INTEGER)
-  let flag = await putU16(0)
-  let data = await put32(value)
+function encode(value) {
+  let type = putU16(INTEGER)
+  let flag = putU16(0)
+  let data = put32(value)
 
   // TODO x64
 

--- a/src/put/put_var/integer.js
+++ b/src/put/put_var/integer.js
@@ -7,7 +7,7 @@ const put32 = require('../put_32')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   let type = putU16(INTEGER)
   let flag = putU16(0)
   let data = put32(value)

--- a/src/put/put_var/null.js
+++ b/src/put/put_var/null.js
@@ -4,7 +4,7 @@ const { NULL } = require('../../constants')
  * Encode Null
  * @returns {{value: Buffer, length: Number}}
  */
-function encode() {
+function encode () {
   let buf = Buffer.alloc(4)
   buf.writeUInt32LE(NULL, 0)
   return buf

--- a/src/put/put_var/null.js
+++ b/src/put/put_var/null.js
@@ -4,7 +4,7 @@ const { NULL } = require('../../constants')
  * Encode Null
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode () {
+function encode() {
   let buf = Buffer.alloc(4)
   buf.writeUInt32LE(NULL, 0)
   return buf

--- a/src/put/put_var/string.js
+++ b/src/put/put_var/string.js
@@ -7,9 +7,9 @@ const putString = require('../put_string')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-async function encode (value) {
-  let type = await putU32(STRING)
-  let data = await putString(value)
+function encode(value) {
+  let type = putU32(STRING)
+  let data = putString(value)
   return Buffer.concat([type, data])
 }
 

--- a/src/put/put_var/string.js
+++ b/src/put/put_var/string.js
@@ -7,7 +7,7 @@ const putString = require('../put_string')
  * @param value
  * @returns {{value: Buffer, length: Number}}
  */
-function encode(value) {
+function encode (value) {
   let type = putU32(STRING)
   let data = putString(value)
   return Buffer.concat([type, data])

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -8,11 +8,11 @@ const expect = chai.expect
 const GdCom = require('../src')
 
 let data = {
-  Null: [ null ],
-  Boolean: [ true, false ],
-  Integer: [ 42, -42, 0 ],
-  Float: [ -42.4, 42.45, 0.0, 0.15 ],
-  String: [ 'test', 'test2', 'true', 'false' ],
+  Null: [null],
+  Boolean: [true, false],
+  Integer: [42, -42, 0],
+  Float: [-42.4, 42.45, 0.0, 0.15],
+  String: ['test', 'test2', 'true', 'false'],
   Dictionary: [{
     test2: null,
     true: false,
@@ -21,7 +21,7 @@ let data = {
     dataDeepFile
   }],
   Array: [
-    [ null, true, false, 12, -12, 'test', 'test2' ],
+    [null, true, false, 12, -12, 'test', 'test2'],
     dataFile
   ]
 }
@@ -31,156 +31,121 @@ describe('gd-com binary serializer', () => {
     it(`should encode/decode variant ${objecType}`, () => {
       let dataType = data[objecType]
 
-      return dataType.reduce((promise, value) => {
-        return promise
-          .then(() => GdCom.putVar(value))
-          .then((encoded) => GdCom.getVar(encoded))
-          .then((decoded) => {
-            if (/Float/i.test(objecType)) {
-              expect(decoded.value).to.be.closeTo(value, 0.00001)
-            } else {
-              expect(decoded.value).to.deep.equal(value)
-            }
-          })
-      }, Promise.resolve())
+      dataType.forEach((value) => {
+        var encoded = GdCom.putVar(value);
+        var decoded = GdCom.getVar(encoded);
+
+        if (/Float/i.test(objecType)) {
+          expect(decoded.value).to.be.closeTo(value, 0.00001)
+        } else {
+          expect(decoded.value).to.deep.equal(value)
+        }
+      })
     })
   }
 
   // signed int
   it(`should encode/decode int 8`, () => {
     const values = [-128, 127, 10, -10]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.put8(value))
-        .then((encoded) => GdCom.get8(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.put8(value);
+      var decoded = GdCom.get8(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode int 16`, () => {
     const values = [-32768, 32767, 10, -10]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.put16(value))
-        .then((encoded) => GdCom.get16(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.put16(value);
+      var decoded = GdCom.get16(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode int 32`, () => {
     const values = [-2147483648, 2147483647, 10, -10]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.put32(value))
-        .then((encoded) => GdCom.get32(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.put32(value);
+      var decoded = GdCom.get32(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode int 64`, () => {
     const values = [Long.MAX_VALUE.toString(), Long.MIN_VALUE.toString(), '10', '518']
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.put64(value))
-        .then((encoded) => GdCom.get64(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.be.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.put64(value);
+      var decoded = GdCom.get64(encoded);
+      expect(decoded.value).to.be.equal(value)
+    })
   })
 
   // unsigned int
   it(`should encode/decode uint 8`, () => {
     const values = [0, 255, 10, 105]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putU8(value))
-        .then((encoded) => GdCom.getU8(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putU8(value);
+      var decoded = GdCom.getU8(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode uint 16`, () => {
     const values = [0, 65535, 10, 518]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putU16(value))
-        .then((encoded) => GdCom.getU16(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putU16(value);
+      var decoded = GdCom.getU16(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode uint 32`, () => {
     const values = [0, 4294967295, 10, 518]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putU32(value))
-        .then((encoded) => GdCom.getU32(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putU32(value);
+      var decoded = GdCom.getU32(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   it(`should encode/decode uint 64`, () => {
     const values = [Long.MAX_UNSIGNED_VALUE.toString(), '0', '10', '518']
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putU64(value))
-        .then((encoded) => GdCom.getU64(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.be.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putU64(value);
+      var decoded = GdCom.getU64(encoded);
+      expect(decoded.value).to.be.equal(value)
+    })
   })
 
   // string
   it(`should encode/decode string`, () => {
     const values = ['hello', 'world', 'hello world', 'hello world hello world']
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putString(value))
-        .then((encoded) => GdCom.getString(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.equal(value)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putString(value);
+      var decoded = GdCom.getString(encoded);
+      expect(decoded.value).to.deep.equal(value)
+    })
   })
 
   // float
   it(`should encode/decode float`, () => {
     const values = [10.520, -10.520]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putFloat(value))
-        .then((encoded) => GdCom.getFloat(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.closeTo(value, 0.00001)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putFloat(value);
+      var decoded = GdCom.getFloat(encoded);
+      expect(decoded.value).to.deep.closeTo(value, 0.00001)
+    })
   })
 
   // double
   it(`should encode/decode double`, () => {
     const values = [10.520, -10.520]
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => GdCom.putDouble(value))
-        .then((encoded) => GdCom.getDouble(encoded))
-        .then((decoded) => {
-          expect(decoded.value).to.deep.closeTo(value, 0.00001)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      var encoded = GdCom.putDouble(value);
+      var decoded = GdCom.getDouble(encoded);
+      expect(decoded.value).to.deep.closeTo(value, 0.00001)
+    })
   })
 
   // gdBuffer Test
@@ -190,29 +155,26 @@ describe('gd-com binary serializer', () => {
 
     const values = ['test', 'test1', 'test2']
 
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => buffer.putVar(value))
-        .then(() => buffer.getVar())
-        .then((test) => {
-          expect(test).to.be.equal(value)
-          expect(buffer.getBuffer().equals(Buffer.alloc(0))).to.be.equals(true)
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      buffer.putVar(value);
+      var test = buffer.getVar();
+      expect(test).to.be.equal(value)
+      expect(buffer.getBuffer().equals(Buffer.alloc(0))).to.be.equals(true)
+    })
   })
 
   it(`gdBuffer should encode/decode with buffer length`, async () => {
     let buffer = new GdCom.GdBuffer()
 
-    await buffer.putVar('test')
-    await buffer.putVar('test')
-    await buffer.putVar('test')
-    await buffer.putVar('test')
-    let test = await buffer.getVar()
+    buffer.putVar('test')
+    buffer.putVar('test')
+    buffer.putVar('test')
+    buffer.putVar('test')
+    let test = buffer.getVar()
     expect(test).to.be.equal('test')
-    test = await buffer.getVar()
+    test = buffer.getVar()
     expect(test).to.be.equal('test')
-    test = await buffer.getVar()
+    test = buffer.getVar()
     expect(test).to.be.equal('test')
 
     expect(buffer.getBuffer().length).to.be.equals(12)
@@ -223,15 +185,12 @@ describe('gd-com binary serializer', () => {
 
     const values = ['test', 'test1', 'test2']
 
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => buffer.putVar(value))
-        .then(() => buffer.getVar())
-        .then((test) => {
-          expect(test).to.be.equal(value)
-          expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      buffer.putVar(value);
+      var test = buffer.getVar()
+      expect(test).to.be.equal(value)
+      expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
+    })
   })
 
   it(`should encode/decode integer and be empty`, () => {
@@ -239,15 +198,12 @@ describe('gd-com binary serializer', () => {
 
     const values = [-100, 100, 500, 8520]
 
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => buffer.putVar(value))
-        .then(() => buffer.getVar())
-        .then((test) => {
-          expect(test).to.be.equal(value)
-          expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      buffer.putVar(value);
+      var test = buffer.getVar();
+      expect(test).to.be.equal(value)
+      expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
+    })
   })
 
   it(`should encode/decode float and be empty`, () => {
@@ -255,34 +211,31 @@ describe('gd-com binary serializer', () => {
 
     const values = [1.5, -1.5, 500.5, 8520, 8520]
 
-    return values.reduce((promise, value) => {
-      return promise
-        .then(() => buffer.putVar(value))
-        .then(() => buffer.getVar())
-        .then((test) => {
-          expect(test).to.be.equal(value)
-          expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
-        })
-    }, Promise.resolve())
+    values.forEach((value) => {
+      buffer.putVar(value);
+      var test = buffer.getVar();
+      expect(test).to.be.equal(value)
+      expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
+    })
   })
 
   it(`should encode/decode and contains test4`, async () => {
     let buffer = new GdCom.GdBuffer(Buffer.alloc(0))
 
-    await buffer.putVar('test1')
-    await buffer.putVar('test2')
-    await buffer.putVar('test3')
-    await buffer.putVar('test4')
+    buffer.putVar('test1')
+    buffer.putVar('test2')
+    buffer.putVar('test3')
+    buffer.putVar('test4')
 
-    let test = await buffer.getVar()
+    let test = buffer.getVar()
     expect(test).to.be.equal('test1')
     expect(buffer.getBuffer().length).to.be.equals(48)
 
-    test = await buffer.getVar()
+    test = buffer.getVar()
     expect(test).to.be.equal('test2')
     expect(buffer.getBuffer().length).to.be.equals(32)
 
-    test = await buffer.getVar()
+    test = buffer.getVar()
     expect(test).to.be.equal('test3')
     expect(buffer.getBuffer().length).to.be.equals(16)
   })

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -32,8 +32,8 @@ describe('gd-com binary serializer', () => {
       let dataType = data[objecType]
 
       dataType.forEach((value) => {
-        var encoded = GdCom.putVar(value);
-        var decoded = GdCom.getVar(encoded);
+        var encoded = GdCom.putVar(value)
+        var decoded = GdCom.getVar(encoded)
 
         if (/Float/i.test(objecType)) {
           expect(decoded.value).to.be.closeTo(value, 0.00001)
@@ -48,8 +48,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode int 8`, () => {
     const values = [-128, 127, 10, -10]
     values.forEach((value) => {
-      var encoded = GdCom.put8(value);
-      var decoded = GdCom.get8(encoded);
+      var encoded = GdCom.put8(value)
+      var decoded = GdCom.get8(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -57,8 +57,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode int 16`, () => {
     const values = [-32768, 32767, 10, -10]
     values.forEach((value) => {
-      var encoded = GdCom.put16(value);
-      var decoded = GdCom.get16(encoded);
+      var encoded = GdCom.put16(value)
+      var decoded = GdCom.get16(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -66,8 +66,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode int 32`, () => {
     const values = [-2147483648, 2147483647, 10, -10]
     values.forEach((value) => {
-      var encoded = GdCom.put32(value);
-      var decoded = GdCom.get32(encoded);
+      var encoded = GdCom.put32(value)
+      var decoded = GdCom.get32(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -75,8 +75,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode int 64`, () => {
     const values = [Long.MAX_VALUE.toString(), Long.MIN_VALUE.toString(), '10', '518']
     values.forEach((value) => {
-      var encoded = GdCom.put64(value);
-      var decoded = GdCom.get64(encoded);
+      var encoded = GdCom.put64(value)
+      var decoded = GdCom.get64(encoded)
       expect(decoded.value).to.be.equal(value)
     })
   })
@@ -85,8 +85,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode uint 8`, () => {
     const values = [0, 255, 10, 105]
     values.forEach((value) => {
-      var encoded = GdCom.putU8(value);
-      var decoded = GdCom.getU8(encoded);
+      var encoded = GdCom.putU8(value)
+      var decoded = GdCom.getU8(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -94,8 +94,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode uint 16`, () => {
     const values = [0, 65535, 10, 518]
     values.forEach((value) => {
-      var encoded = GdCom.putU16(value);
-      var decoded = GdCom.getU16(encoded);
+      var encoded = GdCom.putU16(value)
+      var decoded = GdCom.getU16(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -103,8 +103,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode uint 32`, () => {
     const values = [0, 4294967295, 10, 518]
     values.forEach((value) => {
-      var encoded = GdCom.putU32(value);
-      var decoded = GdCom.getU32(encoded);
+      var encoded = GdCom.putU32(value)
+      var decoded = GdCom.getU32(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -112,8 +112,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode uint 64`, () => {
     const values = [Long.MAX_UNSIGNED_VALUE.toString(), '0', '10', '518']
     values.forEach((value) => {
-      var encoded = GdCom.putU64(value);
-      var decoded = GdCom.getU64(encoded);
+      var encoded = GdCom.putU64(value)
+      var decoded = GdCom.getU64(encoded)
       expect(decoded.value).to.be.equal(value)
     })
   })
@@ -122,8 +122,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode string`, () => {
     const values = ['hello', 'world', 'hello world', 'hello world hello world']
     values.forEach((value) => {
-      var encoded = GdCom.putString(value);
-      var decoded = GdCom.getString(encoded);
+      var encoded = GdCom.putString(value)
+      var decoded = GdCom.getString(encoded)
       expect(decoded.value).to.deep.equal(value)
     })
   })
@@ -132,8 +132,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode float`, () => {
     const values = [10.520, -10.520]
     values.forEach((value) => {
-      var encoded = GdCom.putFloat(value);
-      var decoded = GdCom.getFloat(encoded);
+      var encoded = GdCom.putFloat(value)
+      var decoded = GdCom.getFloat(encoded)
       expect(decoded.value).to.deep.closeTo(value, 0.00001)
     })
   })
@@ -142,8 +142,8 @@ describe('gd-com binary serializer', () => {
   it(`should encode/decode double`, () => {
     const values = [10.520, -10.520]
     values.forEach((value) => {
-      var encoded = GdCom.putDouble(value);
-      var decoded = GdCom.getDouble(encoded);
+      var encoded = GdCom.putDouble(value)
+      var decoded = GdCom.getDouble(encoded)
       expect(decoded.value).to.deep.closeTo(value, 0.00001)
     })
   })
@@ -156,8 +156,8 @@ describe('gd-com binary serializer', () => {
     const values = ['test', 'test1', 'test2']
 
     values.forEach((value) => {
-      buffer.putVar(value);
-      var test = buffer.getVar();
+      buffer.putVar(value)
+      var test = buffer.getVar()
       expect(test).to.be.equal(value)
       expect(buffer.getBuffer().equals(Buffer.alloc(0))).to.be.equals(true)
     })
@@ -186,7 +186,7 @@ describe('gd-com binary serializer', () => {
     const values = ['test', 'test1', 'test2']
 
     values.forEach((value) => {
-      buffer.putVar(value);
+      buffer.putVar(value)
       var test = buffer.getVar()
       expect(test).to.be.equal(value)
       expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
@@ -199,8 +199,8 @@ describe('gd-com binary serializer', () => {
     const values = [-100, 100, 500, 8520]
 
     values.forEach((value) => {
-      buffer.putVar(value);
-      var test = buffer.getVar();
+      buffer.putVar(value)
+      var test = buffer.getVar()
       expect(test).to.be.equal(value)
       expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
     })
@@ -212,8 +212,8 @@ describe('gd-com binary serializer', () => {
     const values = [1.5, -1.5, 500.5, 8520, 8520]
 
     values.forEach((value) => {
-      buffer.putVar(value);
-      var test = buffer.getVar();
+      buffer.putVar(value)
+      var test = buffer.getVar()
       expect(test).to.be.equal(value)
       expect(buffer.getBuffer()).to.be.deep.equals(Buffer.alloc(0))
     })

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -163,7 +163,7 @@ describe('gd-com binary serializer', () => {
     })
   })
 
-  it(`gdBuffer should encode/decode with buffer length`, async () => {
+  it(`gdBuffer should encode/decode with buffer length`, () => {
     let buffer = new GdCom.GdBuffer()
 
     buffer.putVar('test')
@@ -219,7 +219,7 @@ describe('gd-com binary serializer', () => {
     })
   })
 
-  it(`should encode/decode and contains test4`, async () => {
+  it(`should encode/decode and contains test4`, () => {
     let buffer = new GdCom.GdBuffer(Buffer.alloc(0))
 
     buffer.putVar('test1')


### PR DESCRIPTION
This PR removes all `async` and `await` syntax for the library.

When used in combination with an EventEmitter, any thrown errors will be swallowed by an `async` function.  If async is needed, it's better to use `process.nextTick` and take a callback.

Closes #1 