### PR TITLE
Fix padding when reading dictionaries and arrays

### DIFF
--- a/src/get/get_var/array.js
+++ b/src/get/get_var/array.js
@@ -19,9 +19,10 @@ function getVarArray (genericDecoder, buf) {
 
   for (let index = 0; index < nbEntries; index++) {
     const decodedValue = genericDecoder(data.buffer)
+    const nextBufferOffset = (decodedValue.length + ((4 - decodedValue.length % 4) % 4)) + 4 // Pad to 4 bytes + 4 bytes type
     data.array.push(decodedValue.value)
-    data.buffer = data.buffer.slice(decodedValue.length + 4)
-    data.pos += decodedValue.length + 4
+    data.buffer = data.buffer.slice(nextBufferOffset)
+    data.pos += nextBufferOffset
   }
 
   return {

--- a/src/get/get_var/dictionnary.js
+++ b/src/get/get_var/dictionnary.js
@@ -22,9 +22,10 @@ function getVarDictionnary (genericDecoder, buf) {
     const nextBuffer = data.buffer.slice(decodedKey.length + 4)
 
     const decodedValue = genericDecoder(nextBuffer)
-    data.pos += decodedValue.length + 4 // 4 type length
+    const nextBufferOffset = (decodedValue.length + ((4 - decodedValue.length % 4) % 4)) + 4 // Pad to 4 bytes + 4 bytes type
+    data.pos += nextBufferOffset
     data.dictionary[decodedKey.value] = decodedValue.value
-    data.buffer = nextBuffer.slice(decodedValue.length + 4)
+    data.buffer = nextBuffer.slice(nextBufferOffset)
   }
 
   return {


### PR DESCRIPTION
Currently, this library does not take padding into account when deserializing Dictionaries and Arrays with e.g. PoolByteArrays that have been padded to 4 bytes.